### PR TITLE
fix compatibility with VkNet 1.75.0

### DIFF
--- a/VkNet.AudioBypassService/Extensions/AudioDownloadExtensions.cs
+++ b/VkNet.AudioBypassService/Extensions/AudioDownloadExtensions.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using VkNet.Abstractions;
-using VkNet.Model.Attachments;
+using VkNet.Model;
 
 namespace VkNet.AudioBypassService.Extensions
 {

--- a/VkNet.AudioBypassService/Utils/RestClientWithUserAgent.cs
+++ b/VkNet.AudioBypassService/Utils/RestClientWithUserAgent.cs
@@ -1,5 +1,9 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using VkNet.Abstractions.Utils;
@@ -9,7 +13,7 @@ namespace VkNet.AudioBypassService.Utils
 {
 	/// <inheritdoc cref="IRestClient" />
 	[UsedImplicitly]
-	public class RestClientWithUserAgent : RestClient
+	public class RestClientWithUserAgent : IRestClient
 	{
 		private static readonly IDictionary<string, string> VkHeaders = new Dictionary<string, string>
 		{
@@ -17,12 +21,34 @@ namespace VkNet.AudioBypassService.Utils
 			{ "x-vk-android-client", "new" }
 		};
 
-		public RestClientWithUserAgent(HttpClient httpClient, ILogger<RestClient> logger) : base(httpClient, logger)
+		private readonly RestClient _restClientProxy;
+
+		public RestClientWithUserAgent(HttpClient httpClient, ILogger<RestClient> logger)
 		{
+			_restClientProxy = new RestClient(httpClient, logger);
+
 			foreach (var header in VkHeaders)
 			{
-				httpClient.DefaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
+				_restClientProxy.HttpClient.DefaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
 			}
+		}
+
+		/// <inheritdoc />
+		public Task<HttpResponse<string>> GetAsync(Uri uri, IEnumerable<KeyValuePair<string, string>> parameters, Encoding encoding, CancellationToken token = default)
+		{
+			return _restClientProxy.GetAsync(uri, parameters, encoding, token);
+		}
+
+		/// <inheritdoc />
+		public Task<HttpResponse<string>> PostAsync(Uri uri, IEnumerable<KeyValuePair<string, string>> parameters, Encoding encoding, IEnumerable<KeyValuePair<string, string>> headers = null, CancellationToken token = default)
+		{
+			return _restClientProxy.PostAsync(uri, parameters, encoding, headers, token);
+		}
+
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			_restClientProxy?.Dispose();
 		}
 	}
 }

--- a/VkNet.AudioBypassService/VkAndroidAuthorization.cs
+++ b/VkNet.AudioBypassService/VkAndroidAuthorization.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
@@ -40,7 +41,7 @@ namespace VkNet.AudioBypassService
 			_logger = logger;
 		}
 
-		public async Task<AuthorizationResult> AuthorizeAsync()
+		public async Task<AuthorizationResult> AuthorizeAsync(CancellationToken token = default)
 		{
 			_logger?.LogDebug("1. Авторизация");
 			var authResult = await BaseAuthAsync().ConfigureAwait(false);

--- a/VkNet.AudioBypassService/VkNet.AudioBypassService.csproj
+++ b/VkNet.AudioBypassService/VkNet.AudioBypassService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
-		<Version>1.7.5</Version>
+		<Version>1.7.6</Version>
 		<Description>
 			Расширение для VkNet для обхода ограничения к методам Audio и Messages ВКонтакте API.
 		</Description>
@@ -16,6 +16,6 @@
 		<PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="all" />
 		<PackageReference Include="SonarAnalyzer.CSharp" Version="8.48.0.56517" PrivateAssets="all" />
         <PackageReference Include="protobuf-net" Version="3.1.25" />
-        <PackageReference Include="VkNet" Version="1.73.0" />
+        <PackageReference Include="VkNet" Version="1.75.0" />
 	</ItemGroup>
 </Project>

--- a/examples/ConsoleApp/Program.cs
+++ b/examples/ConsoleApp/Program.cs
@@ -1,10 +1,9 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using VkNet;
 using VkNet.Abstractions;
 using VkNet.AudioBypassService.Extensions;
 using VkNet.Model;
-using VkNet.Model.RequestParams;
 
 namespace ConsoleApp
 {


### PR DESCRIPTION
- добавлен CancellationToken в качестве параметра метода AuthorizeAsync в класс VkAndroidAuthorization
- изменена структура класса RestClientWithUserAgent: RestClient теперь используется как приватное поле, т.к. в текущей имплементации VkNet RestClient имеет модификатор sealed